### PR TITLE
warn about template contamination

### DIFF
--- a/data-products-dp0-2/index.rst
+++ b/data-products-dp0-2/index.rst
@@ -99,7 +99,7 @@ Coadd images are divided into **"tracts"** (a spherical convex polygon) and trac
 A PVI which has had a template image subtracted from it.
 Any source detected in a difference image represents the *time-variable* flux component of the astrophysical object.
 
-Template images are, for DP0.2, built from the third best seeing visits from all 5 years of the DC2 simultion.
+Template images are, for DP0.2, built from the top one-third best seeing visits from all 5 years of the DC2 simulation.
 This is not representative of the future LSST data products; the plan is for templates applied to a given year of data are built from images obtained the year before, and for the coaddition process to take care to remove transient or fast moving objects (see Section 3.4.3 of the `DPDD <https://ls.st/dpdd/>`_).
 It is important to note that because of how the DP0.2 templates were built, there is transient flux in the template images, which leads to negative flux offsets in the measured difference-image fluxes.
 Work to help delegates identify, quantify, and correct for this issue when using the time-domain data products for DC2 Type Ia supernovae is underway.

--- a/data-products-dp0-2/index.rst
+++ b/data-products-dp0-2/index.rst
@@ -100,7 +100,7 @@ A PVI which has had a template image subtracted from it.
 Any source detected in a difference image represents the *time-variable* flux component of the astrophysical object.
 
 Template images are, for DP0.2, built from the third best seeing visits from all 5 years of the DC2 simultion.
-This is not representative of the future LSST data products; the plan is for templates applied to a given year of data are built from images obtained the year before, and for the coaddition process to take care to remove transient or fast moving objects (see Section 3.4.3 of the `DPDD <ls.st/dpdd>`_).
+This is not representative of the future LSST data products; the plan is for templates applied to a given year of data are built from images obtained the year before, and for the coaddition process to take care to remove transient or fast moving objects (see Section 3.4.3 of the `DPDD <https://ls.st/dpdd/>`_).
 It is important to note that because of how the DP0.2 templates were built, there is transient flux in the template images, which leads to negative flux offsets in the measured difference-image fluxes.
 Work to help delegates identify, quantify, and correct for this issue when using the time-domain data products for DC2 Type Ia supernovae is underway.
 The documentation and tutorials will be updated in the future, and in the meantime please reach out to Melissa Graham.

--- a/data-products-dp0-2/index.rst
+++ b/data-products-dp0-2/index.rst
@@ -100,8 +100,8 @@ A PVI which has had a template image subtracted from it.
 Any source detected in a difference image represents the *time-variable* flux component of the astrophysical object.
 
 Template images are, for DP0.2, built from the top one-third best seeing visits from all 5 years of the DC2 simulation.
-This is not representative of the future LSST data products; the plan is for templates applied to a given year of data are built from images obtained the year before, and for the coaddition process to take care to remove transient or fast moving objects (see Section 3.4.3 of the `DPDD <https://ls.st/dpdd/>`_).
-It is important to note that because of how the DP0.2 templates were built, there is transient flux in the template images, which leads to negative flux offsets in the measured difference-image fluxes.
+This is not representative of the future LSST data products; the plan is for templates applied to a given year of data to be built from images obtained the year before, and for the coaddition process to take care to remove transient or fast moving objects (see Section 3.4.3 of the `DPDD <https://ls.st/dpdd/>`_).
+It is important to note that because of how the DP0.2 templates were built, there is often transient flux in the template images, which leads to negative flux offsets in the measured difference-image fluxes.
 Work to help delegates identify, quantify, and correct for this issue when using the time-domain data products for DC2 Type Ia supernovae is underway.
 The documentation and tutorials will be updated in the future, and in the meantime please reach out to Melissa Graham.
 

--- a/data-products-dp0-2/index.rst
+++ b/data-products-dp0-2/index.rst
@@ -97,8 +97,14 @@ Coadd images are divided into **"tracts"** (a spherical convex polygon) and trac
 
 **Difference Image**:
 A PVI which has had a template image subtracted from it.
-Template images are built from images obtained the previous year.
 Any source detected in a difference image represents the *time-variable* flux component of the astrophysical object.
+
+Template images are, for DP0.2, built from the third best seeing visits from all 5 years of the DC2 simultion.
+This is not representative of the future LSST data products; the plan is for templates applied to a given year of data are built from images obtained the year before, and for the coaddition process to take care to remove transient or fast moving objects (see Section 3.4.3 of the `DPDD <ls.st/dpdd>`_).
+It is important to note that because of how the DP0.2 templates were built, there is transient flux in the template images, which leads to negative flux offsets in the measured difference-image fluxes.
+Work to help delegates identify, quantify, and correct for this issue when using the time-domain data products for DC2 Type Ia supernovae is underway.
+The documentation and tutorials will be updated in the future, and in the meantime please reach out to Melissa Graham.
+
 In the butler, find difference exposures as "goodSeeingDiff_differenceExp", and the templates as "goodSeeingDiff_templateExp".
 
 .. _DP0-2-Data-Products-DPDD-Catalogs:

--- a/tutorials-examples/portal-intermediate.rst
+++ b/tutorials-examples/portal-intermediate.rst
@@ -41,6 +41,12 @@ This tutorial uses the Astronomy Data Query Language (ADQL) to query and retriev
 ADQL is similar to SQL (Structured Query Language), and the `documentation for ADQL <https://www.ivoa.net/documents/latest/ADQL.html>`_ includes more information about syntax and keywords.
 For more information about the DP0.2 catalogs, visit the :ref:`DP0-2-Data-Products-DPDD` or the `DP0.2 Catalog Schema Browser <https://dm.lsst.org/sdm_schemas/browser/dp02.html>`_.
 
+**WARNING:** In this tutorial, the difference-image fluxes are converted to magnitudes in the TAP query.
+This is usually safe to do, because supernovae fluxes should never be negative in a difference image -- unless the supernova also appears in the template image.
+In the case of DP0.2, due to how the template images were built, some of the template images are contaminated with supernova flux, potentially up to 40% of DC2 SNIa.
+This leads to negative-flux difference-image detections that are significant (SNR>5), and thus an overall offset in the SNIa lightcurves.
+Work is ongoing to evaluate this issue and recommend a robust correction method (see :ref:`DP0-2-Data-Products-DPDD-Images`).
+Note that this offset is not discoverable in the following tutorial.
 
 
 .. _DP0-2-Portal-Intermediate_Step-1:


### PR DESCRIPTION
Added warnings to the DP0.2 DPDD section on difference images, and to the top of the Portal tutorial 02. 