### PR TITLE
Tickets/preops 4724

### DIFF
--- a/data-access-analysis-tools/api-intro.rst
+++ b/data-access-analysis-tools/api-intro.rst
@@ -35,6 +35,9 @@ Longer term, Rubin Observatory will support `SCS <https://www.ivoa.net/documents
 `SIAv2 <https://www.ivoa.net/documents/SIA/20150730/index.html>`_ for image searches, and `VOSpace <https://www.ivoa.net/documents/VOSpace/>`_ 
 (in addition to `WebDAV <https://en.wikipedia.org/wiki/WebDAV>`_) for access to user files.
 
+As described below, the API aspect permits Rubin data access both from inside the RSP environment (e.g., via the RSP notebook aspect) and from outside the RSP environment (e.g., via `TOPCAT <http://www.star.bris.ac.uk/~mbt/topcat/>`_ or from a ``pyvo``-enabled environment like NOIRLab's `Astro Data Lab <https://datalab.noirlab.edu/>`_).  Currently, there are no additional database constraints imposed on external environments:  as for the internal RSP enviroment, the database server will generally be unable to process queries that have an internal intermediate form that is larger than roughly 5GB, and the TAP service will have difficulties with final results that are over roughly 2GB in size.  That said, this is by no means the final word on what limits might be in operations.
+
+
 .. Important::
     The API Aspect has a lot of new features for DP0.2, which will eventually be added to this page.
     Check back soon for new information!

--- a/data-access-analysis-tools/api-intro.rst
+++ b/data-access-analysis-tools/api-intro.rst
@@ -192,9 +192,11 @@ As with the TOPCAT example above, one needs an RSP access token.
 Either generate one as described above in :ref:`Data-Access-Analysis-Tools-TAP-TOPCAT`, 
 or just use a previously generated (but unexpired) RSP access token.
 Ideally, copy the RSP access token into a file in your home directory
-that is only read/write by the file owner and that is accessible to 
+that is only read/write accessible by the file owner and that is accessible to 
 the python session that will be accessed in the steps below.  Specifically, 
-in a UNIX/MacOS/Linux environment, the following commands can be performed. 
+in a UNIX/MacOS/Linux environment, the following commands can be performed
+in order to create this file in a secure manner that avoids exposing the
+RSP token to outside resources for even a short period of time.
 
 * Open a terminal window (**not** a Jupyter notebook) on your computer or in your non-RSP user environoment.
 
@@ -204,17 +206,29 @@ in a UNIX/MacOS/Linux environment, the following commands can be performed.
 
    cd ~
 
-* Create a file in the home directory containing the RSP token.  One can do this via the ``echo`` command.  In the following, ``<token>`` is to be replaced by the the actual RSP token string.  Note that using a 'hidden' file -- one with a name that starts with a ``.`` -- aids security.
+* In the home directory, create an empty file that will eventually contain the RSP token.  One can do this via the ``touch`` command.  Note that using a 'hidden' file -- one with a name that starts with a ``.`` -- improves security.
 
 .. code-block:: python
 
-   echo '<token>' > .rsp-tap.token
+   touch .rsp-tap.token
 
-* Change the permissions on the file containing the RSP token to remove world and group read/write access.  The ``chmod 600`` command will do this while maintaining read/write access for the file owner.
+* Change the permissions on this file to remove world and group read/write access.  The ``chmod 600`` command will do this while maintaining read/write access for the file owner.
 
 .. code-block:: python
 
    chmod 600 .rsp-tap.token
+
+* Insert the RSP token into this file securely.  The following command permits this by requesting the file owner to enter the RSP token at the first prompt.
+
+.. code-block:: python
+
+   cat <<EOF > .rsp-tap.token
+
+* Close this file by issuing an "end of file" command at the second prompt.  After entering this command, the file is ready for use for as long as the RSP token is unexpired.
+
+.. code-block:: python
+
+   EOF
 
 **2. Start up a python session.**  This could be a standalone python session running on (say) a laptop, or a Jupyter notebook running elsewhere but displayed on one's own browser.
 

--- a/data-access-analysis-tools/api-intro.rst
+++ b/data-access-analysis-tools/api-intro.rst
@@ -35,7 +35,14 @@ Longer term, Rubin Observatory will support `SCS <https://www.ivoa.net/documents
 `SIAv2 <https://www.ivoa.net/documents/SIA/20150730/index.html>`_ for image searches, and `VOSpace <https://www.ivoa.net/documents/VOSpace/>`_ 
 (in addition to `WebDAV <https://en.wikipedia.org/wiki/WebDAV>`_) for access to user files.
 
-As described below, the API aspect permits Rubin data access both from inside the RSP environment (e.g., via the RSP notebook aspect) and from outside the RSP environment (e.g., via `TOPCAT <http://www.star.bris.ac.uk/~mbt/topcat/>`_ or from a ``pyvo``-enabled environment like NOIRLab's `Astro Data Lab <https://datalab.noirlab.edu/>`_).  Currently, there are no additional database constraints imposed on external environments:  as for the internal RSP enviroment, the database server will generally be unable to process queries that have an internal intermediate form that is larger than roughly 5GB, and the TAP service will have difficulties with final results that are over roughly 2GB in size.  That said, this is by no means the final word on what limits might be in operations.
+As described below, the API aspect permits Rubin data access both from inside the RSP environment (e.g., via the RSP notebook aspect) and 
+from outside the RSP environment (e.g., via `TOPCAT <http://www.star.bris.ac.uk/~mbt/topcat/>`_ or from a ``pyvo``-enabled environment like 
+NOIRLab's `Astro Data Lab <https://datalab.noirlab.edu/>`_).  
+
+Currently, there are no additional database constraints imposed on external environments.  
+As for the internal RSP enviroment, the database server will generally be unable to process queries that have an internal intermediate form 
+that is larger than roughly 5GB, and the TAP service will have difficulties with final results that are over roughly 2GB in size.  
+That said, this is by no means the final word on what limits might be in operations.
 
 
 .. Important::

--- a/data-access-analysis-tools/api-intro.rst
+++ b/data-access-analysis-tools/api-intro.rst
@@ -224,7 +224,7 @@ RSP token to outside resources for even a short period of time.
 
    cat <<EOF > .rsp-tap.token
 
-* Close this file by issuing an "end of file" command at the second prompt.  After entering this command, the file is ready for use for as long as the RSP token is unexpired.
+* Close this file by issuing an "end of file" command at the second prompt.  After entering this command, the file will be ready for use for as long as the RSP token is unexpired.
 
 .. code-block:: python
 


### PR DESCRIPTION
Made the following changes to `/data-access-analysis-tools/api-intro.html` to address [PREOPS-4724](https://jira.lsstcorp.org/browse/PREOPS-4724):

1. Added paragraph to "Introduction to the RSP API Aspect" section to note that, currently, there are no additional constraints on the Rubin database server on requests made outside the official RSP environment (e.g., from TOPCAT or from NOIRLab's Astro Data Lab) beyond those internal to the RSP environment (e.g., on queries that have intermediate forms larger than roughly 5GB in size or final results larger than roughly 2GB in size)...  although this could change during Rubin operations.  This text is based on Gregory Dubois-Felsmann's response in in this dm-rsp-support thread ([link](https://lsstc.slack.com/archives/CAS7Y9ADS/p1701990928302739)).  See rendered text [here](https://dp0-2.lsst.io/v/PREOPS-4724/data-access-analysis-tools/api-intro.html#introduction-to-the-rsp-api-aspect).  
2. Updated method for securely creating a file containing the RSP token in one's own home directory in an external environment based on Kian-Tat Lim's suggeston in this dm-rsp-support thread ([link](https://lsstc.slack.com/archives/CAS7Y9ADS/p1701990928302739)).  See rendered text under step 1 [here](https://dp0-2.lsst.io/v/PREOPS-4724/data-access-analysis-tools/api-intro.html#get-started-with-pyvo). 

[PREOPS-4724]: https://rubinobs.atlassian.net/browse/PREOPS-4724?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ