### PR TITLE
Tickets/preops 5153 patch

### DIFF
--- a/tutorials-examples/Portal-6.rst
+++ b/tutorials-examples/Portal-6.rst
@@ -26,7 +26,7 @@
 
 **Contact authors:** Yumi Choi
 
-**Last verified to run:** 2024-10-18
+**Last verified to run:** 2024-10-22
 
 **Targeted learning level:** Beginner 
 
@@ -290,6 +290,6 @@ user-supplied tables. Refer to the available tutorials for detailed instructions
 `Portal <https://dp0-3.lsst.io/tutorials-dp0-3/portal-dp0-3-5.html>`_ and
 `Jupyter Notebooks <https://dp0-3.lsst.io/tutorials-dp0-3/rendered_nb_03_06.html>`_. 
 
-**Portal FAQ page"** `Link to the Portal FAQ page <https://dp0-2.lsst.io/v/PREOPS-5150/data-access-analysis-tools/portal-future-faq.html>`_
+`Link to the Portal FAQ page <https://dp0-2.lsst.io/v/PREOPS-5150/data-access-analysis-tools/portal-future-faq.html>`_
 
 

--- a/tutorials-examples/index.rst
+++ b/tutorials-examples/index.rst
@@ -69,6 +69,7 @@ The tutorials below are step-by-step demonstrations of how to use the Portal Asp
     portal-images
     portal-4
     Portal-5
+    Portal-6
 
 
 .. _DP0-2-Tutorials-Notebooks:

--- a/tutorials-examples/major-updates-log.rst
+++ b/tutorials-examples/major-updates-log.rst
@@ -51,6 +51,10 @@ and clicking on "history" (near upper-right).
 Major Updates Log
 =================
 
+Oct 22 2024
+-----------
+Released new portal tutorial 6 demonstrating various functionalities available in the Firefly-based RSP Portal Asepct.
+
 Sep 19 2024
 -----------
 


### PR DESCRIPTION
updated the last verified date in the portal tutorial and removed an unnecessary extra text at the bottom of the tutorial. Also, update the log to add this new portal tutorial. 